### PR TITLE
Task4182_Update_test_site_ElementButtonsGroups_shaped

### DIFF
--- a/components/groups/button_groups/MandatoryButtonGroup.vue
+++ b/components/groups/button_groups/MandatoryButtonGroup.vue
@@ -15,6 +15,7 @@
         </v-col>
         <v-btn-toggle
           v-model="toggle_exclusive"
+          shaped
           mandatory
         >
           <v-btn>


### PR DESCRIPTION
For testing purposes (according to traceability matrix) Mandatory button group in ButtonGroups was changed into 'shaped'
![image](https://user-images.githubusercontent.com/55189259/184833841-53f37a3b-fc4b-4c43-8c51-e6bbb8ab0be5.png)
