### PR TITLE
4397 Update breadcrumbs page

### DIFF
--- a/components/breadcrumbs/DarkThemeRippleBreadcrumbs.vue
+++ b/components/breadcrumbs/DarkThemeRippleBreadcrumbs.vue
@@ -1,0 +1,35 @@
+<template>
+    <div>
+      <v-breadcrumbs
+        dark
+        :items="items"
+        v-ripple
+        divider="/"
+      >
+      </v-breadcrumbs>
+    </div>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    items: [
+      {
+        text: 'Dashboard',
+        disabled: false,
+        href: '#dashboard',
+      },
+      {
+        text: 'Link 1',
+        disabled: false,
+        href: '#link1',
+      },
+      {
+        text: 'Link 2',
+        disabled: true,
+        href: '#link2',
+      },
+    ],
+  }),
+};
+</script>

--- a/pages/Breadcrumbs.vue
+++ b/pages/Breadcrumbs.vue
@@ -34,6 +34,10 @@
         Item slot breadcrumbs
       </p>
       <ItemSlotBreadcrumbs id="itemSlotBreadcrumbs"/>
+      <p class="text-h5">
+        Dark theme ripple breadcrumbs
+      </p>
+      <DarkThemeRippleBreadcrumbs id="darkThemeRippleBreadcrumbs"/>
     
   </v-container>
   
@@ -45,6 +49,7 @@ import DifferentDividersBreadcrumbs from '@/components/breadcrumbs/DifferentDivi
 import LargeBreadcrumbs from '@/components/breadcrumbs/LargeBreadcrumbs.vue';
 import CustomDividersBreadcrumbs from '@/components/breadcrumbs/CustomDividersBreadcrumbs.vue';
 import ItemSlotBreadcrumbs from '@/components/breadcrumbs/ItemSlotBreadcrumbs.vue';
+import DarkThemeRippleBreadcrumbs from '@/components/breadcrumbs/DarkThemeRippleBreadcrumbs.vue';
 
 export default {
   name: 'Breadcrumbs',
@@ -53,6 +58,7 @@ export default {
     LargeBreadcrumbs,
     CustomDividersBreadcrumbs,
     ItemSlotBreadcrumbs,
+    DarkThemeRippleBreadcrumbs
   },
 };
 </script>


### PR DESCRIPTION
The ripple on the Breadcrumbs element appears on click, but there is no v-ripple attribute in the DOM structure appearing. Just the position attribute is changing from static to relative. It doesn’t happen if there is no ripple