### PR TITLE
4298_slideGroupActiveClassIssueFix

### DIFF
--- a/components/groups/slide_groups/ActiveClassSlideGroup.vue
+++ b/components/groups/slide_groups/ActiveClassSlideGroup.vue
@@ -9,7 +9,6 @@
       class="pa-4"
       active-class="success"
       show-arrows
-      mandatory
     >
       <v-slide-item
         v-for="n in 15"

--- a/pages/Slide-Groups.vue
+++ b/pages/Slide-Groups.vue
@@ -10,7 +10,7 @@
 
         <v-col>
             <p class="text-h5">
-                Active class slide group (mandatory slide)
+                Active class slide group
             </p>
             <ActiveClassSlideGroup id="ActiveClassSlideGroup" />
         </v-col>


### PR DESCRIPTION
active class slide group should not be 'mandatory' as it is 'single'
so the 'mandatory' prop added by N.Vozizov is deleted
it is necessary for testing purposes